### PR TITLE
Aggiungo un avviso di esclusione DNS per l'API Octopus

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ logger:
     custom_components.octopus_energy_it: debug
 ```
 
+> [!WARNING]  
+>Se utilizzi un DNS personalizzato, potrebbero verificarsi problemi di collegamento all’API di Octopus Energy Italy, con errori di login anche quando le credenziali inserite sono corrette.
+>In questo caso, è necessario aggiungere al tuo DNS la seguente regola di esclusione: `@@||oeit-kraken.energy^v`
+
 ## Installazione
 
 ### HACS (consigliata)


### PR DESCRIPTION
Ho aggiunto una nota nel `README` per segnalare un possibile problema di autenticazione con l’API Octopus Energy Italy quando si utilizzano DNS personalizzati o filtri DNS. In alcuni casi il login può fallire anche con credenziali corrette.

La modifica include anche un suggerimento per implementare la regola di esclusione da aggiungere al DNS `@@||oeit-kraken.energy^` così da facilitare la risoluzione del problema per gli utenti interessati.