### PR TITLE
Remove fabricated fallback electricity tariff, add repair issue (#15)

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -2,6 +2,7 @@ name: Tag and Release on manifest.json version change
 
 on:
   push:
+    branches: [main]
     paths:
       - 'custom_components/octopus_energy_it/manifest.json'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [1.2.4] - 2026-06-26
 
 ### Changed
-- The "No electricity products for account ...; registering fallback tariff" log entry is now emitted at `INFO` level instead of `WARNING`. This is an expected, handled condition (e.g. during onboarding or while transitioning from another supplier, before Octopus has registered an active tariff) and was previously showing up as a recurring warning in the Home Assistant log on every coordinator refresh. (Fixes #15)
+- Replaced the fabricated "Fallback Electricity Tariff" (a hardcoded, made-up 0.30 EUR/kWh product) with a proper Home Assistant repair issue. When an account has no active electricity product — e.g. during onboarding or while transitioning from another supplier, before Octopus has registered an active tariff — the integration no longer invents fake pricing data. Instead it raises a non-fixable `no_electricity_tariff` repair issue (Settings → System → Repairs) that clears itself automatically once a real tariff is registered. The electricity price/product sensors correctly report as unavailable in the meantime instead of showing fictitious values.
+- The related log entry ("No electricity products for account ...") is now emitted at `INFO` level instead of `WARNING`, since this is an expected, handled condition rather than an error; it previously showed up as a recurring warning on every coordinator refresh. (Fixes #15)
 
 ## [1.2.3] - 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.4] - 2026-06-26
+## [1.2.5] - 2026-06-26
 
 ### Changed
 - Replaced the fabricated "Fallback Electricity Tariff" (a hardcoded, made-up 0.30 EUR/kWh product) with a proper Home Assistant repair issue. When an account has no active electricity product — e.g. during onboarding or while transitioning from another supplier, before Octopus has registered an active tariff — the integration no longer invents fake pricing data. Instead it raises a non-fixable `no_electricity_tariff` repair issue (Settings → System → Repairs) that clears itself automatically once a real tariff is registered. The electricity price/product sensors correctly report as unavailable in the meantime instead of showing fictitious values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.4] - 2026-06-26
+
+### Changed
+- The "No electricity products for account ...; registering fallback tariff" log entry is now emitted at `INFO` level instead of `WARNING`. This is an expected, handled condition (e.g. during onboarding or while transitioning from another supplier, before Octopus has registered an active tariff) and was previously showing up as a recurring warning in the Home Assistant log on every coordinator refresh. (Fixes #15)
+
 ## [1.2.3] - 2026-03-18
 
 ### Changed

--- a/custom_components/octopus_energy_it/README.md
+++ b/custom_components/octopus_energy_it/README.md
@@ -203,7 +203,7 @@ I test coprono:
 | `tests/test_switch.py` | Switch: available, is_on (pending/timeout), turn_on/off, coordinator update, boost charge |
 | `tests/test_binary_sensor.py` | Binary sensor: finestre attive/future/passate, proprietà available (tutti i rami) |
 | `tests/test_coordinator.py` | Coordinator: fetch dati, retry tariffe pubbliche, gestione errori |
-| `tests/test_data_processor.py` | Elaborazione dati API: ledger, punti di prelievo, dispatch, tariffe fallback, scadenze contratto, dispositivi, letture elettricità, prodotti disponibili |
+| `tests/test_data_processor.py` | Elaborazione dati API: ledger, punti di prelievo, dispatch, gestione assenza tariffa attiva, scadenze contratto, dispositivi, letture elettricità, prodotti disponibili |
 
 ### Lint e formattazione
 

--- a/custom_components/octopus_energy_it/__init__.py
+++ b/custom_components/octopus_energy_it/__init__.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import utcnow
@@ -42,6 +43,25 @@ ATTR_ACCOUNT_NUMBER = "account_number"
 ATTR_DEVICE_ID = "device_id"
 ATTR_TARGET_PERCENTAGE = "target_percentage"
 ATTR_TARGET_TIME = "target_time"
+
+
+def _update_electricity_tariff_issue(
+    hass: HomeAssistant, account_number: str, has_tariff: bool
+) -> None:
+    """Create or clear the repair issue for an account with no active tariff."""
+    issue_id = f"no_electricity_tariff_{account_number}"
+    if has_tariff:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+    else:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="no_electricity_tariff",
+            translation_placeholders={"account_number": account_number},
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -164,6 +184,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             account_data, account_num, api, available_products
                         )
                         all_accounts_data.update(processed)
+                        _update_electricity_tariff_issue(
+                            hass,
+                            account_num,
+                            processed[account_num].get(
+                                "has_electricity_tariff", False
+                            ),
+                        )
                     else:
                         _LOGGER.warning(
                             "Failed to fetch data for account %s", account_num
@@ -329,6 +356,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        account_numbers = entry.data.get("account_numbers") or (
+            [entry.data["account_number"]] if entry.data.get("account_number") else []
+        )
+        for account_num in account_numbers:
+            ir.async_delete_issue(hass, DOMAIN, f"no_electricity_tariff_{account_num}")
+
         domain_data = hass.data[DOMAIN]
         domain_data.pop(entry.entry_id, None)
         remaining_entries = [

--- a/custom_components/octopus_energy_it/data_processor.py
+++ b/custom_components/octopus_energy_it/data_processor.py
@@ -66,6 +66,7 @@ async def process_api_data(
             "devices_raw": [],
             "products": [],
             "products_raw": [],
+            "has_electricity_tariff": False,
             "gas_products": [],
             "vehicle_battery_size_in_kwh": None,
             "current_start": None,
@@ -426,42 +427,14 @@ async def process_api_data(
         )
     else:
         _LOGGER.info(
-            "No electricity products for account %s; registering fallback tariff "
+            "No electricity products for account %s "
             "(expected during onboarding or supplier transition)",
             account_number,
         )
-        products = [
-            {
-                "code": "FALLBACK_ELECTRICITY",
-                "description": "Fallback electricity tariff",
-                "name": "Fallback Electricity Tariff",
-                "displayName": "Fallback Electricity Tariff",
-                "validFrom": None,
-                "validTo": None,
-                "agreementId": None,
-                "productType": None,
-                "isTimeOfUse": False,
-                "type": "Simple",
-                "timeslots": [],
-                "termsAndConditionsUrl": None,
-                "pricing": {
-                    "base": 0.30,
-                    "f2": None,
-                    "f3": None,
-                    "units": "EUR/kWh",
-                    "annualStandingCharge": None,
-                    "annualStandingChargeUnits": None,
-                },
-                "params": {},
-                "rawPrices": {},
-                "supplyPoint": {},
-                "unitRateForecast": [],
-                "grossRate": "30",
-            }
-        ]
 
     result_data[account_number]["products"] = products
     result_data[account_number]["products_raw"] = products
+    result_data[account_number]["has_electricity_tariff"] = bool(products)
 
     current_electricity_product = _select_current_product(products)
     result_data[account_number]["current_electricity_product"] = (

--- a/custom_components/octopus_energy_it/data_processor.py
+++ b/custom_components/octopus_energy_it/data_processor.py
@@ -425,8 +425,9 @@ async def process_api_data(
             account_number,
         )
     else:
-        _LOGGER.warning(
-            "No electricity products for account %s; registering fallback tariff",
+        _LOGGER.info(
+            "No electricity products for account %s; registering fallback tariff "
+            "(expected during onboarding or supplier transition)",
             account_number,
         )
         products = [

--- a/custom_components/octopus_energy_it/manifest.json
+++ b/custom_components/octopus_energy_it/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "python-graphql-client==0.4.3"
   ],
-  "version": "1.2.4"
+  "version": "1.2.5"
 }

--- a/custom_components/octopus_energy_it/manifest.json
+++ b/custom_components/octopus_energy_it/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "python-graphql-client==0.4.3"
   ],
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/custom_components/octopus_energy_it/strings.json
+++ b/custom_components/octopus_energy_it/strings.json
@@ -53,6 +53,12 @@
       "message": "Unable to update the charge end time. Check the log for details."
     }
   },
+  "issues": {
+    "no_electricity_tariff": {
+      "title": "No active electricity tariff",
+      "description": "No active electricity product was found for account {account_number}. This is expected while onboarding or during a transition from another supplier, before Octopus registers an active tariff — electricity price and tariff sensors will be unavailable until then. This issue clears automatically once a tariff is registered, no action is required."
+    }
+  },
   "entity": {
     "sensor": {
       "electricity_price": {

--- a/custom_components/octopus_energy_it/translations/en.json
+++ b/custom_components/octopus_energy_it/translations/en.json
@@ -55,6 +55,12 @@
       "message": "Unable to update the charge end time. Check the log for details."
     }
   },
+  "issues": {
+    "no_electricity_tariff": {
+      "title": "No active electricity tariff",
+      "description": "No active electricity product was found for account {account_number}. This is expected while onboarding or during a transition from another supplier, before Octopus registers an active tariff — electricity price and tariff sensors will be unavailable until then. This issue clears automatically once a tariff is registered, no action is required."
+    }
+  },
   "entity": {
     "sensor": {
       "electricity_price": {

--- a/custom_components/octopus_energy_it/translations/it.json
+++ b/custom_components/octopus_energy_it/translations/it.json
@@ -55,6 +55,12 @@
       "message": "Impossibile aggiornare l'orario di fine ricarica. Controlla i log per i dettagli."
     }
   },
+  "issues": {
+    "no_electricity_tariff": {
+      "title": "Nessuna tariffa elettrica attiva",
+      "description": "Non è stato trovato nessun prodotto elettrico attivo per l'account {account_number}. È normale durante l'onboarding o il passaggio da un altro operatore, prima che Octopus registri una tariffa attiva: i sensori di prezzo e tariffa elettrica resteranno non disponibili fino ad allora. Questo avviso si chiude automaticamente quando viene registrata una tariffa, non è richiesta alcuna azione."
+    }
+  },
   "entity": {
     "sensor": {
       "electricity_price": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,14 @@ def _install_stubs() -> None:
     if not hasattr(_dr, "DeviceInfo"):
         _dr.DeviceInfo = dict
 
+    _ir = _stub("homeassistant.helpers.issue_registry")
+    if not hasattr(_ir, "async_create_issue"):
+        _ir.async_create_issue = MagicMock()
+        _ir.async_delete_issue = MagicMock()
+        _ir.IssueSeverity = types.SimpleNamespace(
+            CRITICAL="critical", ERROR="error", WARNING="warning"
+        )
+
     _ep = _stub("homeassistant.helpers.entity_platform")
     if not hasattr(_ep, "AddEntitiesCallback"):
         _ep.AddEntitiesCallback = type("AddEntitiesCallback", (), {})

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -948,3 +948,40 @@ class TestProcessDispatchData:
         ]
         result = _process_dispatches(dispatches, self._now())
         assert result["planned_dispatches"] is dispatches
+
+
+# ---------------------------------------------------------------------------
+# _update_electricity_tariff_issue — repair issue create/clear
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateElectricityTariffIssue:
+
+    def test_no_tariff_creates_issue(self):
+        from homeassistant.helpers import issue_registry as ir
+
+        ir.async_create_issue.reset_mock()
+        ir.async_delete_issue.reset_mock()
+        hass = MagicMock()
+
+        init_mod._update_electricity_tariff_issue(hass, "A-1234", False)
+
+        ir.async_create_issue.assert_called_once()
+        ir.async_delete_issue.assert_not_called()
+        _, kwargs = ir.async_create_issue.call_args
+        assert kwargs["translation_key"] == "no_electricity_tariff"
+        assert kwargs["translation_placeholders"] == {"account_number": "A-1234"}
+
+    def test_has_tariff_clears_issue(self):
+        from homeassistant.helpers import issue_registry as ir
+
+        ir.async_create_issue.reset_mock()
+        ir.async_delete_issue.reset_mock()
+        hass = MagicMock()
+
+        init_mod._update_electricity_tariff_issue(hass, "A-1234", True)
+
+        ir.async_delete_issue.assert_called_once_with(
+            hass, init_mod.DOMAIN, "no_electricity_tariff_A-1234"
+        )
+        ir.async_create_issue.assert_not_called()

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -328,17 +328,17 @@ class TestProcessApiDataElectricitySupplyPoint:
 class TestProcessApiDataFallbackTariff:
 
     @pytest.mark.asyncio
-    async def test_no_products_inserts_fallback(self):
+    async def test_no_products_leaves_products_empty(self):
         api = _make_api()
         data = _minimal_account_data()
         data["products"] = []
         result = await process_api_data(data, ACCOUNT, api, {})
-        products = result[ACCOUNT]["products"]
-        assert len(products) == 1
-        assert products[0]["code"] == "FALLBACK_ELECTRICITY"
+        assert result[ACCOUNT]["products"] == []
+        assert result[ACCOUNT]["current_electricity_product"] is None
+        assert result[ACCOUNT]["has_electricity_tariff"] is False
 
     @pytest.mark.asyncio
-    async def test_with_products_no_fallback(self):
+    async def test_with_products_sets_has_electricity_tariff(self):
         api = _make_api()
         data = _minimal_account_data()
         data["products"] = [
@@ -351,8 +351,8 @@ class TestProcessApiDataFallbackTariff:
         ]
         result = await process_api_data(data, ACCOUNT, api, {})
         codes = [p["code"] for p in result[ACCOUNT]["products"]]
-        assert "FALLBACK_ELECTRICITY" not in codes
         assert "FLEX" in codes
+        assert result[ACCOUNT]["has_electricity_tariff"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes the hardcoded "Fallback Electricity Tariff" (a fabricated 0.30 EUR/kWh product) that was previously injected when an account had no active electricity product.
- When no active product is found, the integration now raises a non-fixable `no_electricity_tariff` Home Assistant repair issue (Settings → System → Repairs) instead of inventing pricing data; it clears itself automatically once a real tariff is registered.
- The related log entry is now emitted at `INFO` instead of `WARNING`, since this is an expected condition (onboarding / supplier transition), not an error.
- Fixes the CI/CD misconfiguration that let `tag-and-release.yaml` cut a release from this feature branch before merge: the workflow now only triggers on pushes to `main`.

## Test plan
- [x] `python -m pytest tests/` — 274 passed
- [x] New/updated tests for `has_electricity_tariff` flag in `data_processor.py` and for `_update_electricity_tariff_issue` in `__init__.py`
- [x] Verified `strings.json` / `translations/en.json` / `translations/it.json` are valid JSON
- [x] Confirmed old `v1.2.4` tag/release (erroneously published from this branch) were removed manually before merge

Fixes #15


---
_Generated by [Claude Code](https://claude.ai/code/session_018DrMsZeiGoNuAMoibvDdqy)_